### PR TITLE
args_runner.py s/name/task_name/

### DIFF
--- a/packages/dash_evals/src/dash_evals/runner/args_runner.py
+++ b/packages/dash_evals/src/dash_evals/runner/args_runner.py
@@ -35,7 +35,7 @@ def _run_from_args(args: argparse.Namespace) -> bool:
         dataset = json_dataset(str(args.dataset))
 
     # Build the task instance
-    task_def = {"name": args.task}
+    task_def = {"task_name": args.task}
     task_instance = task_func(dataset, task_def) if dataset else task_func(None, task_def)
 
     # Set up logging


### PR DESCRIPTION
Fix getting started flow

```
run-evals \
  --task question_answer \
  --model google/gemini-2.5-flash \
  --dataset ./my_first_sample.json
```

which fails with:
```
Failed to run evaluation: 'task_name'
```

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/< Replace with issue link here >

> It's a good idea to open an issue first for discussion.

- [ ] All tests pass
- [ ] Appropriate inline docstrings changes are included in the PR
- [ ] Appropriate documentation changes to the [docs](./docs) site are included in the PR
